### PR TITLE
feat(registry-importer): add termination message

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -47,6 +47,13 @@ type VddkInfo struct {
 	Host    string
 }
 
+// RegistryImporterInfo holds complete import report returned by a registry importer pod
+type RegistryImporterInfo struct {
+	SourceImageSize        int    `json:"source-image-size"`
+	SourceImageVirtualSize int    `json:"source-image-virtual-size"`
+	SourceImageFormat      string `json:"source-image-format"`
+}
+
 // RandAlphaNum provides an implementation to generate a random alpha numeric string of the specified length
 func RandAlphaNum(n int) string {
 	rand.Seed(time.Now().UnixNano())


### PR DESCRIPTION
1. Added termination message for registry-importer
2. Added source image size check (it is taken from the `Content-Length` header, which may come with a zero value)
