### PR TITLE
Feature/add xz gz and iso sources

### DIFF
--- a/cmd/cdi-registry-importer/importer.go
+++ b/cmd/cdi-registry-importer/importer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/stream"
+	"github.com/pkg/errors"
 	"golang.org/x/sync/errgroup"
 	"io"
 	"k8s.io/klog/v2"
@@ -71,6 +72,7 @@ const (
 	imageInfoSize        = 64 * 1024 * 1024
 	pipeBufSize          = 64 * 1024 * 1024
 	tempImageInfoPattern = "tempfile"
+	isoImageType         = "iso"
 )
 
 func (i *Importer) Run(ctx context.Context) error {
@@ -279,19 +281,18 @@ func (i *Importer) inspectAndStreamSourceImage(ctx context.Context, sourceImageF
 
 	errsGroup, ctx := errgroup.WithContext(ctx)
 
-	imageInfoSourceReader, imageInfoSourceWriter := nio.Pipe(buffer.New(imageInfoSize))
-	sourceReader := io.TeeReader(sourceImageReader, imageInfoSourceWriter)
+	imageInfoReader, imageInfoWriter := nio.Pipe(buffer.New(imageInfoSize))
 
 	errsGroup.Go(func() error {
 		defer tarWriter.Close()
 		defer pipeWriter.Close()
 		defer sourceImageReader.Close()
-		defer imageInfoSourceWriter.Close()
+		defer imageInfoWriter.Close()
 
 		klog.Infoln("Streaming from the source")
-		doneSize, err := io.Copy(streamWriter, sourceReader)
+		doneSize, err := io.Copy(streamWriter, io.TeeReader(sourceImageReader, imageInfoWriter))
 		if err != nil {
-			return fmt.Errorf("error copying file contents: %w", err)
+			return fmt.Errorf("error copying from the source: %w", err)
 		}
 
 		if doneSize != int64(sourceImageSize) {
@@ -310,9 +311,9 @@ func (i *Importer) inspectAndStreamSourceImage(ctx context.Context, sourceImageF
 	})
 
 	errsGroup.Go(func() error {
-		defer imageInfoSourceReader.Close()
+		defer imageInfoReader.Close()
 
-		info, err := getImageInfo(ctx, imageInfoSourceReader)
+		info, err := getImageInfo(ctx, imageInfoReader)
 		if err != nil {
 			return err
 		}
@@ -342,7 +343,7 @@ func (i *Importer) newDataSource(_ context.Context) (importer.DataSourceInterfac
 	return result, nil
 }
 
-func (i *Importer) uploadLayersAndImage(ctx context.Context, pipeReader *nio.PipeReader, sourceImageSize int, ImageInfoCh chan ImageInfo) error {
+func (i *Importer) uploadLayersAndImage(ctx context.Context, pipeReader *nio.PipeReader, sourceImageSize int, imageInfoCh chan ImageInfo) error {
 	nameOpts := i.destNameOptions()
 	remoteOpts := i.destRemoteOptions(ctx)
 	image := empty.Image
@@ -365,16 +366,18 @@ func (i *Importer) uploadLayersAndImage(ctx context.Context, pipeReader *nio.Pip
 	}
 	klog.Infoln("Layer uploaded")
 
-	imageInfo := <-ImageInfoCh
-
 	cnf, err := image.ConfigFile()
 	if err != nil {
 		return fmt.Errorf("error getting image config: %w", err)
 	}
 
+	imageInfo := <-imageInfoCh
+
+	klog.Infof("Got image info: %+v", imageInfo)
+
 	cnf.Config.Labels = map[string]string{}
-	cnf.Config.Labels[imageLabelSourceImageVirtualSize] = fmt.Sprintf("%d", imageInfo.VirtualSize)
 	cnf.Config.Labels[imageLabelSourceImageSize] = fmt.Sprintf("%d", sourceImageSize)
+	cnf.Config.Labels[imageLabelSourceImageVirtualSize] = fmt.Sprintf("%d", imageInfo.VirtualSize)
 	cnf.Config.Labels[imageLabelSourceImageFormat] = imageInfo.Format
 
 	image, err = mutate.ConfigFile(image, cnf)
@@ -402,76 +405,79 @@ func (i *Importer) uploadLayersAndImage(ctx context.Context, pipeReader *nio.Pip
 func getImageInfo(ctx context.Context, sourceReader io.ReadCloser) (ImageInfo, error) {
 	formatSourceReaders, err := importer.NewFormatReaders(sourceReader, 0)
 	if err != nil {
-		klog.Errorf("Error creating readers: %v", err)
-		return ImageInfo{}, err
+		return ImageInfo{}, fmt.Errorf("error creating format readers: %w", err)
 	}
 
-	klog.Infoln("Creating temp image info file")
-	tempImageInfoFile, err := os.CreateTemp("", tempImageInfoPattern)
-	if err != nil {
-		return ImageInfo{}, fmt.Errorf("error creating temp file: %w", err)
-	}
+	var uncompressedN int64
+	var tempImageInfoFile *os.File
 
-	klog.Infoln("Write to temp image info file")
-	uncompressedN, err := io.CopyN(tempImageInfoFile, formatSourceReaders.TopReader(), imageInfoSize)
-	if err != nil {
-		return ImageInfo{}, fmt.Errorf("error writing to temp file: %w", err)
-	}
-
-	if err = tempImageInfoFile.Close(); err != nil {
-		return ImageInfo{}, fmt.Errorf("error closing temp file: %w", err)
-	}
-
-	cmd := exec.CommandContext(ctx, "qemu-img", "info", "--output=json", tempImageInfoFile.Name())
-	outRaw, err := cmd.Output()
-	if err != nil {
-		return ImageInfo{}, fmt.Errorf("error running qemu-img info: %w", err)
-	}
-
-	var imageInfo ImageInfo
-	if err = json.Unmarshal(outRaw, &imageInfo); err != nil {
-		return ImageInfo{}, fmt.Errorf("error parsing qemu-img info output: %w", err)
-	}
-
-	if imageInfo.Format != "raw" {
-		_, err = io.Copy(&EmptyWriter{}, formatSourceReaders.TopReader())
+	klog.Infoln("Write image info to temp file")
+	{
+		tempImageInfoFile, err = os.CreateTemp("", tempImageInfoPattern)
 		if err != nil {
+			return ImageInfo{}, fmt.Errorf("error creating temp file: %w", err)
+		}
+
+		uncompressedN, err = io.CopyN(tempImageInfoFile, formatSourceReaders.TopReader(), imageInfoSize)
+		if err != nil && !errors.Is(err, io.EOF) {
 			return ImageInfo{}, fmt.Errorf("error writing to temp file: %w", err)
 		}
 
+		if err = tempImageInfoFile.Close(); err != nil {
+			return ImageInfo{}, fmt.Errorf("error closing temp file: %w", err)
+		}
+	}
+
+	klog.Infoln("Get image info from temp file")
+	var imageInfo ImageInfo
+	{
+		cmd := exec.CommandContext(ctx, "qemu-img", "info", "--output=json", tempImageInfoFile.Name())
+		rawOut, err := cmd.Output()
+		if err != nil {
+			return ImageInfo{}, fmt.Errorf("error running qemu-img info: %w", err)
+		}
+
+		klog.Infoln("Qemu-img command output:", string(rawOut))
+
+		if err = json.Unmarshal(rawOut, &imageInfo); err != nil {
+			return ImageInfo{}, fmt.Errorf("error parsing qemu-img info output: %w", err)
+		}
+
+		if imageInfo.Format != "raw" {
+			_, err = io.Copy(&util.EmptyWriter{}, sourceReader)
+			if err != nil {
+				return ImageInfo{}, fmt.Errorf("error copying to nowhere: %w", err)
+			}
+
+			return imageInfo, nil
+		}
+	}
+
+	klog.Infoln("Check the image as it may be an iso")
+	{
+		cmd := exec.CommandContext(ctx, "file", "-b", tempImageInfoFile.Name())
+		rawOut, err := cmd.Output()
+		if err != nil {
+			return ImageInfo{}, fmt.Errorf("error running file info: %w", err)
+		}
+
+		out := string(rawOut)
+
+		klog.Infoln("File command output:", out)
+
+		if strings.HasPrefix(strings.ToLower(out), isoImageType) {
+			imageInfo.Format = isoImageType
+		}
+
+		n, err := io.Copy(&util.EmptyWriter{}, formatSourceReaders.TopReader())
+		if err != nil {
+			return ImageInfo{}, fmt.Errorf("error copying to nowhere: %w", err)
+		}
+
+		imageInfo.VirtualSize = int(uncompressedN + n)
+
 		return imageInfo, nil
 	}
-
-	cmd = exec.CommandContext(ctx, "file", "-b", tempImageInfoFile.Name())
-	outRaw, err = cmd.Output()
-	if err != nil {
-		return ImageInfo{}, fmt.Errorf("error running qemu-img info: %w", err)
-	}
-
-	out := string(outRaw)
-
-	klog.Infoln("Parsing with file command output:", out)
-
-	if strings.HasPrefix(out, "ISO") {
-		imageInfo.Format = "iso"
-	}
-
-	n, err := io.Copy(&EmptyWriter{}, formatSourceReaders.TopReader())
-	if err != nil {
-		return ImageInfo{}, fmt.Errorf("error writing to temp file: %w", err)
-	}
-
-	uncompressedN += n
-
-	imageInfo.VirtualSize = int(uncompressedN)
-
-	return imageInfo, nil
-}
-
-type EmptyWriter struct{}
-
-func (w EmptyWriter) Write(p []byte) (int, error) {
-	return len(p), nil
 }
 
 func writeImportCompleteMessage(sourceImageSize, sourceImageVirtualSize int, sourceImageFormat string) error {

--- a/pkg/importer/http-datasource.go
+++ b/pkg/importer/http-datasource.go
@@ -487,16 +487,7 @@ func getExtraHeadersFromSecrets() ([]string, error) {
 }
 
 func (hs *HTTPDataSource) ReadCloser() (io.ReadCloser, error) {
-	if hs.readers == nil {
-		var err error
-		hs.readers, err = NewFormatReaders(hs.httpReader, hs.contentLength)
-		if err != nil {
-			klog.Errorf("Error creating readers: %v", err)
-			return nil, err
-		}
-	}
-
-	return hs.readers.TopReader(), nil
+	return hs.httpReader, nil
 }
 
 func (hs *HTTPDataSource) Length() (int, error) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -105,6 +105,12 @@ func (r *CountingReader) Close() error {
 	return r.Reader.Close()
 }
 
+type EmptyWriter struct{}
+
+func (w EmptyWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
 // GetAvailableSpaceByVolumeMode calls another method based on the volumeMode parameter to get the amount of
 // available space at the path specified.
 func GetAvailableSpaceByVolumeMode(volumeMode v1.PersistentVolumeMode) (int64, error) {


### PR DESCRIPTION
1. Added support for compressed images (xz and gz) ([click](https://github.com/deckhouse/3p-containerized-data-importer/pull/6/files#diff-91c77f07a1d5c99b040c8f352e6438b0542a17506618216b64d8d3fb37681988R406))
2. Added support for iso images ([click](https://github.com/deckhouse/3p-containerized-data-importer/pull/6/files#diff-91c77f07a1d5c99b040c8f352e6438b0542a17506618216b64d8d3fb37681988R459))