### PR TITLE
fix(registry-importer): fix registry importer pushing

### DIFF
--- a/Taskfile.dist.yaml
+++ b/Taskfile.dist.yaml
@@ -2,7 +2,7 @@ version: "3"
 silent: true
 
 env:
-  REGISTRY_IMPORTER_IMAGE: ghcr.io/werf/cdi-registry-importer:latest
+  REGISTRY_IMPORTER_IMAGE: k3d-registry.virtualization-controller.test:5000/cdi-registry-importer:latest
 
 tasks:
   cdi-registry-importer:build:
@@ -13,5 +13,5 @@ tasks:
   cdi-registry-importer:push:
     desc: "build and push"
     cmds:
-      - task: build
-      - docker push ghcr.io/werf/cdi-registry-importer:latest
+      - task: cdi-registry-importer:build
+      - docker push ${REGISTRY_IMPORTER_IMAGE}

--- a/cdi-registry-importer.Dockerfile
+++ b/cdi-registry-importer.Dockerfile
@@ -9,7 +9,9 @@ RUN go build ./cmd/cdi-registry-importer && \
 FROM debian:bookworm-slim
 RUN apt-get -qq update && apt-get -qq install -y --no-install-recommends \
     ca-certificates \
-    libnbd0 && \
+    libnbd0 \
+    qemu-utils \
+    file && \
     rm -rf /var/lib/apt/lists/*
 COPY --from=builder /go/src/github.com/deckhouse/3p-containerized-data-importer/cdi-registry-importer /usr/local/bin/cdi-registry-importer
 CMD ["/usr/local/bin/cdi-registry-importer"]


### PR DESCRIPTION
1. Fixed name of registry to push cdi-registry-importer
2. Added qemu-img and file deps to execute cdi-registry-importer in docker