### PR TITLE
Migrating the DataSourceInterface

### DIFF
--- a/pkg/importer/data-processor.go
+++ b/pkg/importer/data-processor.go
@@ -18,7 +18,6 @@ package importer
 
 import (
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 
@@ -92,10 +91,6 @@ type DataSourceInterface interface {
 	GetURL() *url.URL
 	// Close closes any readers or other open resources.
 	Close() error
-
-	Filename() (string, error)
-	Length() (int, error)
-	ReadCloser() (io.ReadCloser, error)
 }
 
 // ResumableDataSource is the interface all resumeable data sources should implement

--- a/pkg/importer/gcs-datasource.go
+++ b/pkg/importer/gcs-datasource.go
@@ -204,15 +204,3 @@ func extractGcsBucketObjectAndHost(s string) (string, string, string) {
 	klog.V(3).Infoln("GCS Importer: GCS Object:", object)
 	return bucket, object, host
 }
-
-func (sd *GCSDataSource) ReadCloser() (io.ReadCloser, error) {
-	panic("not implemented")
-}
-
-func (sd *GCSDataSource) Length() (int, error) {
-	panic("not implemented")
-}
-
-func (sd *GCSDataSource) Filename() (string, error) {
-	panic("not implemented")
-}

--- a/pkg/importer/imageio-datasource.go
+++ b/pkg/importer/imageio-datasource.go
@@ -1472,15 +1472,3 @@ func getOvirtClient(ep string, accessKey string, secKey string, certDir string) 
 		conn: conn,
 	}, err
 }
-
-func (is *ImageioDataSource) ReadCloser() (io.ReadCloser, error) {
-	panic("not implemented")
-}
-
-func (is *ImageioDataSource) Length() (int, error) {
-	panic("not implemented")
-}
-
-func (is *ImageioDataSource) Filename() (string, error) {
-	panic("not implemented")
-}

--- a/pkg/importer/registry-datasource.go
+++ b/pkg/importer/registry-datasource.go
@@ -17,7 +17,6 @@ limitations under the License.
 package importer
 
 import (
-	"io"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -203,16 +202,4 @@ func collectCerts(certDir, targetDir, targetPrefix string) error {
 		}
 	}
 	return nil
-}
-
-func (rd *RegistryDataSource) ReadCloser() (io.ReadCloser, error) {
-	panic("not implemented")
-}
-
-func (rd *RegistryDataSource) Length() (int, error) {
-	panic("not implemented")
-}
-
-func (rd *RegistryDataSource) Filename() (string, error) {
-	panic("not implemented")
 }

--- a/pkg/importer/s3-datasource.go
+++ b/pkg/importer/s3-datasource.go
@@ -214,15 +214,3 @@ func extractBucketAndObject(s string) (string, string) {
 	object := strings.Join(pathSplit[1:], s3FolderSep)
 	return bucket, object
 }
-
-func (sd *S3DataSource) ReadCloser() (io.ReadCloser, error) {
-	panic("not implemented")
-}
-
-func (sd *S3DataSource) Length() (int, error) {
-	panic("not implemented")
-}
-
-func (sd *S3DataSource) Filename() (string, error) {
-	panic("not implemented")
-}

--- a/pkg/importer/transport-public.go
+++ b/pkg/importer/transport-public.go
@@ -1,0 +1,9 @@
+package importer
+
+var (
+	HasPrefix          = hasPrefix
+	IsWhiteout         = isWhiteout
+	IsDir              = isDir
+	BuildSourceContext = buildSourceContext
+	ReadImageSource    = readImageSource
+)

--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -45,6 +45,10 @@ func commandTimeoutContext() (context.Context, context.CancelFunc) {
 	return context.WithCancel(context.Background())
 }
 
+func BuildSourceContext(accessKey, secKey, certDir string, insecureRegistry bool) *types.SystemContext {
+	return buildSourceContext(accessKey, secKey, certDir, insecureRegistry)
+}
+
 func buildSourceContext(accessKey, secKey, certDir string, insecureRegistry bool) *types.SystemContext {
 	ctx := &types.SystemContext{}
 	if accessKey != "" && secKey != "" {
@@ -64,6 +68,10 @@ func buildSourceContext(accessKey, secKey, certDir string, insecureRegistry bool
 	}
 
 	return ctx
+}
+
+func ReadImageSource(ctx context.Context, sys *types.SystemContext, img string) (types.ImageSource, error) {
+	return readImageSource(ctx, sys, img)
 }
 
 func readImageSource(ctx context.Context, sys *types.SystemContext, img string) (types.ImageSource, error) {
@@ -100,6 +108,18 @@ func closeImage(src types.ImageSource) {
 	if err := src.Close(); err != nil {
 		klog.Warningf("Could not close image source: %v ", err)
 	}
+}
+
+func HasPrefix(path string, pathPrefix string) bool {
+	return hasPrefix(path, pathPrefix)
+}
+
+func IsWhiteout(path string) bool {
+	return isWhiteout(path)
+}
+
+func IsDir(hdr *tar.Header) bool {
+	return isDir(hdr)
 }
 
 func hasPrefix(path string, pathPrefix string) bool {

--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -45,10 +45,6 @@ func commandTimeoutContext() (context.Context, context.CancelFunc) {
 	return context.WithCancel(context.Background())
 }
 
-func BuildSourceContext(accessKey, secKey, certDir string, insecureRegistry bool) *types.SystemContext {
-	return buildSourceContext(accessKey, secKey, certDir, insecureRegistry)
-}
-
 func buildSourceContext(accessKey, secKey, certDir string, insecureRegistry bool) *types.SystemContext {
 	ctx := &types.SystemContext{}
 	if accessKey != "" && secKey != "" {
@@ -68,10 +64,6 @@ func buildSourceContext(accessKey, secKey, certDir string, insecureRegistry bool
 	}
 
 	return ctx
-}
-
-func ReadImageSource(ctx context.Context, sys *types.SystemContext, img string) (types.ImageSource, error) {
-	return readImageSource(ctx, sys, img)
 }
 
 func readImageSource(ctx context.Context, sys *types.SystemContext, img string) (types.ImageSource, error) {
@@ -108,18 +100,6 @@ func closeImage(src types.ImageSource) {
 	if err := src.Close(); err != nil {
 		klog.Warningf("Could not close image source: %v ", err)
 	}
-}
-
-func HasPrefix(path string, pathPrefix string) bool {
-	return hasPrefix(path, pathPrefix)
-}
-
-func IsWhiteout(path string) bool {
-	return isWhiteout(path)
-}
-
-func IsDir(hdr *tar.Header) bool {
-	return isDir(hdr)
 }
 
 func hasPrefix(path string, pathPrefix string) bool {

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/google/uuid"
-
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
 

--- a/pkg/importer/upload-datasource.go
+++ b/pkg/importer/upload-datasource.go
@@ -1,10 +1,11 @@
 package importer
 
 import (
-	"github.com/google/uuid"
 	"io"
 	"net/url"
 	"path/filepath"
+
+	"github.com/google/uuid"
 
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
@@ -206,16 +207,4 @@ func (aud *AsyncUploadDataSource) GetURL() *url.URL {
 // GetResumePhase returns the next phase to process when resuming
 func (aud *AsyncUploadDataSource) GetResumePhase() ProcessingPhase {
 	return aud.ResumePhase
-}
-
-func (aud *AsyncUploadDataSource) ReadCloser() (io.ReadCloser, error) {
-	panic("not implemented")
-}
-
-func (aud *AsyncUploadDataSource) Length() (int, error) {
-	panic("not implemented")
-}
-
-func (aud *AsyncUploadDataSource) Filename() (string, error) {
-	panic("not implemented")
 }

--- a/pkg/importer/vddk-datasource_amd64.go
+++ b/pkg/importer/vddk-datasource_amd64.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/url"
 	"os"
 	"regexp"
@@ -1083,16 +1082,4 @@ func (vs *VDDKDataSource) TransferFile(fileName string) (ProcessingPhase, error)
 	}
 
 	return ProcessingPhaseResize, nil
-}
-
-func (vs *VDDKDataSource) ReadCloser() (io.ReadCloser, error) {
-	panic("not implemented")
-}
-
-func (vs *VDDKDataSource) Length() (int, error) {
-	panic("not implemented")
-}
-
-func (vs *VDDKDataSource) Filename() (string, error) {
-	panic("not implemented")
 }

--- a/pkg/importer/vddk-datasource_arm64.go
+++ b/pkg/importer/vddk-datasource_arm64.go
@@ -5,7 +5,6 @@ package importer
 
 import (
 	"errors"
-	"io"
 	"net/url"
 
 	v1 "k8s.io/api/core/v1"
@@ -44,15 +43,3 @@ func NewVDDKDataSource(endpoint string, accessKey string, secKey string, thumbpr
 }
 
 var _ DataSourceInterface = &VDDKDataSource{}
-
-func (V VDDKDataSource) ReadCloser() (io.ReadCloser, error) {
-	panic("not implemented")
-}
-
-func (V VDDKDataSource) Length() (int, error) {
-	panic("not implemented")
-}
-
-func (V VDDKDataSource) Filename() (string, error) {
-	panic("not implemented")
-}


### PR DESCRIPTION
**What this PR does / why we need it**:
Added some public functions that link to private ones.
Methods causing panic have been removed from some datasources. (Filename(), Length(), ReadCloser())
The interface with these methods has been moved to dvcr-importer.


