### PR TITLE
fix(core): add nil check in import-controller.go

### DIFF
--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -344,8 +344,8 @@ func volumeImportSourceName(dv *cdiv1.DataVolume) string {
 func (r *ImportReconciler) reconcileVolumeImportSourceCR(syncState *dvSyncState) error {
 	dv := syncState.dvMutated
 
-	if dv == nil {
-		return errors.New("syncState.dvMutated is nil")
+	if dv.Spec.Source == nil {
+		return errors.New("DataVolume source is nil")
 	}
 
 	importSource := &cdiv1.VolumeImportSource{}

--- a/pkg/controller/datavolume/import-controller.go
+++ b/pkg/controller/datavolume/import-controller.go
@@ -38,6 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	"kubevirt.io/containerized-data-importer/pkg/controller/populators"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
@@ -342,6 +343,11 @@ func volumeImportSourceName(dv *cdiv1.DataVolume) string {
 
 func (r *ImportReconciler) reconcileVolumeImportSourceCR(syncState *dvSyncState) error {
 	dv := syncState.dvMutated
+
+	if dv == nil {
+		return errors.New("syncState.dvMutated is nil")
+	}
+
 	importSource := &cdiv1.VolumeImportSource{}
 	importSourceName := volumeImportSourceName(dv)
 	isMultiStage := dv.Spec.Source != nil && len(dv.Spec.Checkpoints) > 0 &&


### PR DESCRIPTION
This PR fix:

{    "id": "e97611e8-11a0-400f-ac15-c8e55a8c6060",    "file": "/containerized-data-importer/pkg/controller/datavolume/import-controller.go",    "function": "kubevirt.io/containerized-data-importer/pkg/controller/datavolume.ImportReconciler.reconcileVolumeImportSourceCR",    "line": 358,    "locID": 1015,    "lang": "GO",    "tool": "SvEng",    "warnClass": "DEREF_AFTER_NULL.EX",    "mtid": "SvEng.ND.4",    "msg": "After having been compared to a nil value at import-controller.go:346, pointer '(**syncState.dvMutated).Spec->Source' is dereferenced at import-controller.go:358.",    "details": "abb8073da1f9fb5f0df9ac8c09a10288749b95fb",    "flags": 0,    "invariant": "Nqs0YN+E3/hW4FWQHdRfDg",    "optionals": {        "origFunc": "reconcileVolumeImportSourceCR"    },    "fetchContext": {        "projectID": "ebf12caf-a018-4a9f-a237-3f3f96f39686",        "branchID": "229fe666-ba43-4b66-897a-50537502da95",        "snapshotID": "9f7b55b0-a372-4ffa-ba8c-3c1c8d84a796"    }}


