### PR TITLE
fix(core): fixes a problem that occurs when working with CDI and StorageClass without CSIDriver.

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -787,7 +787,7 @@ func GetWorkloadNodePlacement(ctx context.Context, c client.Client) (*sdkapi.Nod
 func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlacement *sdkapi.NodePlacement, primePVC *corev1.PersistentVolumeClaim) (*sdkapi.NodePlacement, error) {
 	var targetPVC corev1.PersistentVolumeClaim
 
-	if usePopulator, ok := primePVC.Annotations[AnnUsePopulator]; ok && usePopulator == "true" {
+	if usePopulator, ok := primePVC.Annotations[AnnUsePopulator]; ok && usePopulator == "false" {
 		targetPVC = *primePVC
 	} else {
 		targetPVCKey := types.NamespacedName{

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -789,7 +789,10 @@ func GetWorkloadNodePlacement(ctx context.Context, c client.Client) (*sdkapi.Nod
 func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlacement *sdkapi.NodePlacement, pvc *corev1.PersistentVolumeClaim) (*sdkapi.NodePlacement, error) {
 	var targetPVC corev1.PersistentVolumeClaim
 
-	if usePopulator, ok := pvc.Annotations[AnnUsePopulator]; ok && usePopulator == "false" {
+	usePopulator, hasPopulatorAnn := pvc.Annotations[AnnUsePopulator]
+	_, hasTolerationsAnn := pvc.Annotations[AnnProvisionerTolerations]
+
+	if (hasPopulatorAnn && usePopulator == "false") || hasTolerationsAnn {
 		targetPVC = *pvc
 	} else {
 		targetPVCKey := types.NamespacedName{

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -799,15 +799,15 @@ func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlace
 			Namespace: pvc.Namespace,
 		}
 
-		err := c.Get(ctx, targetPVCKey, &targetPVC)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get target pvc %s: %w", targetPVCKey, err)
-		}
-
 		for _, ref := range pvc.OwnerReferences {
 			if ref.Kind == "PersistentVolumeClaim" {
 				targetPVCKey.Name = ref.Name
 			}
+		}
+
+		err := c.Get(ctx, targetPVCKey, &targetPVC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get target pvc %s: %w", targetPVCKey, err)
 		}
 	}
 

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -789,10 +789,7 @@ func GetWorkloadNodePlacement(ctx context.Context, c client.Client) (*sdkapi.Nod
 func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlacement *sdkapi.NodePlacement, pvc *corev1.PersistentVolumeClaim) (*sdkapi.NodePlacement, error) {
 	var targetPVC corev1.PersistentVolumeClaim
 
-	usePopulator, hasPopulatorAnn := pvc.Annotations[AnnUsePopulator]
-	_, hasTolerationsAnn := pvc.Annotations[AnnProvisionerTolerations]
-
-	if (hasPopulatorAnn && usePopulator == "false") || hasTolerationsAnn {
+	if usePopulator, ok := pvc.Annotations[AnnUsePopulator]; ok && usePopulator == "false" {
 		targetPVC = *pvc
 	} else {
 		targetPVCKey := types.NamespacedName{

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -784,14 +784,14 @@ func GetWorkloadNodePlacement(ctx context.Context, c client.Client) (*sdkapi.Nod
 }
 
 // AdjustWorkloadNodePlacement adds tolerations specified in prime pvc annotation.
-func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlacement *sdkapi.NodePlacement, primePVC *corev1.PersistentVolumeClaim) (*sdkapi.NodePlacement, error) {
+func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlacement *sdkapi.NodePlacement, pvc *corev1.PersistentVolumeClaim) (*sdkapi.NodePlacement, error) {
 	var targetPVC corev1.PersistentVolumeClaim
 
-	if usePopulator, ok := primePVC.Annotations[AnnUsePopulator]; ok && usePopulator == "false" {
-		targetPVC = *primePVC
+	if usePopulator, ok := pvc.Annotations[AnnUsePopulator]; ok && usePopulator == "false" {
+		targetPVC = *pvc
 	} else {
 		targetPVCKey := types.NamespacedName{
-			Namespace: primePVC.Namespace,
+			Namespace: pvc.Namespace,
 		}
 
 		err := c.Get(ctx, targetPVCKey, &targetPVC)
@@ -799,7 +799,7 @@ func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlace
 			return nil, fmt.Errorf("failed to get target pvc %s: %w", targetPVCKey, err)
 		}
 
-		for _, ref := range primePVC.OwnerReferences {
+		for _, ref := range pvc.OwnerReferences {
 			if ref.Kind == "PersistentVolumeClaim" {
 				targetPVCKey.Name = ref.Name
 			}

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -784,6 +784,8 @@ func GetWorkloadNodePlacement(ctx context.Context, c client.Client) (*sdkapi.Nod
 }
 
 // AdjustWorkloadNodePlacement adds tolerations specified in prime pvc annotation.
+// If the PVC is using populator, the target PVC is the same as the source PVC.
+// UsePopulator annotation is set to "false" to indicate that StorageClass does not have a CSI driver.
 func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlacement *sdkapi.NodePlacement, pvc *corev1.PersistentVolumeClaim) (*sdkapi.NodePlacement, error) {
 	var targetPVC corev1.PersistentVolumeClaim
 


### PR DESCRIPTION
## Description
This PR fixes a problem that occurs when working with CDI and StorageClass without CSIDriver. If StorageClass does not support CSIDriver, then CDI uses the Legacy method of filling disks and images. The current implementation of Tolerations does not support Legacy methods. The patch fixes this by taking Tolerations from the current PVC.

## Why do we need it, and what problem does it solve?
Fixes CDI for StorageClass without CSIDriver.


## What is the expected result?
CDI works as expected on StorageClass without CSIDriver.


## Checklist
- [ ] The code is covered by unit tests.
- [x] e2e tests passed.
- [ ] Documentation updated according to the changes.
- [x] Changes were tested in the Kubernetes cluster manually.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

