### PR TITLE
fix(vd): fix issue with provisioning of a disk created on nfs

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -62,12 +62,13 @@ import (
 
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	cdiv1utils "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1/utils"
+	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
+
 	"kubevirt.io/containerized-data-importer/pkg/client/clientset/versioned/scheme"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
 	"kubevirt.io/containerized-data-importer/pkg/token"
 	"kubevirt.io/containerized-data-importer/pkg/util"
-	sdkapi "kubevirt.io/controller-lifecycle-operator-sdk/api"
 )
 
 const (
@@ -1203,6 +1204,7 @@ func SetRestrictedSecurityContext(podSpec *corev1.PodSpec) {
 			container.SecurityContext.ReadOnlyRootFilesystem = ptr.To[bool](true)
 			container.SecurityContext.RunAsNonRoot = ptr.To[bool](true)
 			container.SecurityContext.RunAsUser = ptr.To[int64](common.QemuSubGid)
+			container.SecurityContext.RunAsGroup = ptr.To[int64](common.QemuSubGid)
 			if len(container.VolumeMounts) > 0 {
 				hasVolumeMounts = true
 			}


### PR DESCRIPTION
**The reason why the NFS server was not working with the `no_root_squash` option:**

- the CSI driver creates PVC as `root:qemu` on the NFS server because fsGroup is set to qemu;
- as the PVC is `drwxrwsr-x root:qemu`, the CDI importer running as `qemu:root` cannot create the disk directory on the PVC (mkdir permission denied).

**Solution: run the CDI importer with gid qemu (runAsGroup: 107).**
