### PR TITLE
Feat/core/read only containers

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1200,6 +1200,7 @@ func SetRestrictedSecurityContext(podSpec *corev1.PodSpec) {
 				Type: corev1.SeccompProfileTypeRuntimeDefault,
 			}
 			container.SecurityContext.AllowPrivilegeEscalation = ptr.To[bool](false)
+			container.SecurityContext.ReadOnlyRootFilesystem = ptr.To[bool](true)
 			container.SecurityContext.RunAsNonRoot = ptr.To[bool](true)
 			container.SecurityContext.RunAsUser = ptr.To[int64](common.QemuSubGid)
 			if len(container.VolumeMounts) > 0 {

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -974,6 +974,12 @@ func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
 					Protocol:      corev1.ProtocolTCP,
 				},
 			},
+			VolumeMounts: []v1.VolumeMount{
+				{
+					Name:      "tmp",
+					MountPath: "/tmp",
+				},
+			},
 		},
 	}
 	if cc.GetVolumeMode(args.pvc) == corev1.PersistentVolumeBlock {
@@ -1045,6 +1051,10 @@ func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
 
 func makeImporterVolumeSpec(args *importerPodArgs) []corev1.Volume {
 	volumes := []corev1.Volume{
+		{
+			Name:         "tmp",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		},
 		{
 			Name: cc.DataVolName,
 			VolumeSource: corev1.VolumeSource{

--- a/pkg/controller/populators/forklift-populator.go
+++ b/pkg/controller/populators/forklift-populator.go
@@ -597,6 +597,7 @@ func makePopulatePodSpec(pvcPrimeName, secretName string) corev1.PodSpec {
 				Name:  populatorContainerName,
 				Ports: []corev1.ContainerPort{{Name: "metrics", ContainerPort: 8443}},
 				SecurityContext: &corev1.SecurityContext{
+					ReadOnlyRootFilesystem:   ptr.To(true),
 					AllowPrivilegeEscalation: ptr.To(false),
 					RunAsNonRoot:             ptr.To(true),
 					RunAsUser:                ptr.To[int64](107),

--- a/pkg/operator/resources/namespaced/controller.go
+++ b/pkg/operator/resources/namespaced/controller.go
@@ -270,6 +270,10 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 			Name:      "uploadserver-client-ca-bundle",
 			MountPath: "/var/run/ca-bundle/cdi-uploadserver-client-signer-bundle",
 		},
+		{
+			Name:      "tmp",
+			MountPath: "/tmp",
+		},
 	}
 	container.Resources = corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -369,6 +373,12 @@ func createControllerDeployment(controllerImage, importerImage, clonerImage, ovi
 					},
 					DefaultMode: &defaultMode,
 				},
+			},
+		},
+		{
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
 	}

--- a/pkg/operator/resources/utils/common.go
+++ b/pkg/operator/resources/utils/common.go
@@ -64,7 +64,8 @@ func CreateContainer(name, image, verbosity, pullPolicy string) corev1.Container
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
-		AllowPrivilegeEscalation: ptr.To[bool](false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
 		RunAsNonRoot:             ptr.To[bool](true),
 	}
 	return *container
@@ -82,7 +83,8 @@ func CreatePortsContainer(name, image, pullPolicy string, ports []corev1.Contain
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
-		AllowPrivilegeEscalation: ptr.To[bool](false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
 		RunAsNonRoot:             ptr.To[bool](true),
 	}
 	return *container


### PR DESCRIPTION
## Description
As part of the integrity control task, we make all containers read-only, including Kubevirt containers, Containerized data importer containers.


## Why do we need it, and what problem does it solve?
These changes improve the ability for integrity checks. Improve security for containers.


## What is the expected result?
All containers from the d8-virtualization namespace, as well as all containers running in a custom namespace, must be created read-only.