### PR TITLE
chore(core): read only cdi

### DIFF
--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -974,12 +974,6 @@ func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
 					Protocol:      corev1.ProtocolTCP,
 				},
 			},
-			VolumeMounts: []v1.VolumeMount{
-				{
-					Name:      "tmp",
-					MountPath: "/tmp",
-				},
-			},
 		},
 	}
 	if cc.GetVolumeMode(args.pvc) == corev1.PersistentVolumeBlock {
@@ -1046,6 +1040,10 @@ func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
 			containers[i].Resources = *args.podResourceRequirements
 		}
 	}
+	containers[0].VolumeMounts = append(containers[0].VolumeMounts, corev1.VolumeMount{
+		MountPath: "/tmp",
+		Name:      "tmp",
+	})
 	return containers
 }
 


### PR DESCRIPTION
## Description
As part of the integrity control task, we make all containers read-only, including Kubevirt containers, Containerized data importer containers.


## Why do we need it, and what problem does it solve?
These changes improve the ability for integrity checks. Improve security for containers.


## What is the expected result?
All containers from the d8-virtualization namespace, as well as all containers running in a custom namespace, must be created read-only.