### PR TITLE
fix(api): watch project quotas to enqueue DataVolumes and populators

### DIFF
--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -333,6 +333,30 @@ func addDataVolumeControllerCommonWatches(mgr manager.Manager, dataVolumeControl
 		return err
 	}
 
+	// When the resourceQuota is updated, it is necessary to trigger reconciliation for all DataVolumes that are waiting for quota expansion or removal.
+	if err := dataVolumeController.Watch(source.Kind(mgr.GetCache(), &corev1.ResourceQuota{}, handler.TypedEnqueueRequestsFromMapFunc[*corev1.ResourceQuota](
+		func(ctx context.Context, obj *corev1.ResourceQuota) []reconcile.Request {
+			dvList := &cdiv1.DataVolumeList{}
+			if err := mgr.GetClient().List(ctx, dvList, &client.ListOptions{Namespace: obj.Namespace}); err != nil {
+				return nil
+			}
+			var reqs []reconcile.Request
+			for _, dv := range dvList.Items {
+				if getDataVolumeOp(ctx, mgr.GetLogger(), &dv, mgr.GetClient()) == op {
+					for _, condition := range dv.Status.Conditions {
+						if condition.Type == patchedDV.QoutaNotExceededConditionType && condition.Status == corev1.ConditionFalse {
+							reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}})
+						}
+					}
+				}
+			}
+			return reqs
+		},
+	),
+	)); err != nil {
+		return err
+	}
+
 	// Watch for PV updates to reconcile the DVs waiting for available PV
 	// Relevant only when the DV StorageSpec has no AccessModes set and no matching StorageClass yet, so PVC cannot be created (test_id:9924,9925)
 	if err := dataVolumeController.Watch(source.Kind(mgr.GetCache(), &corev1.PersistentVolume{}, handler.TypedEnqueueRequestsFromMapFunc[*corev1.PersistentVolume](

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -760,6 +760,14 @@ func (r *ImportReconciler) createScratchPvcForPod(pvc *corev1.PersistentVolumeCl
 					return innerErr
 				}
 			}
+			innerErr := patchedDV.UpdateDVQuotaNotExceededConditionByPVC(r.client, pvc, corev1.ConditionTrue, "", patchedDV.QuotaNotExceededReason)
+			if innerErr != nil {
+				return innerErr
+			}
+			return err
+		}
+		err := patchedDV.UpdateDVQuotaNotExceededConditionByPVC(r.client, pvc, corev1.ConditionTrue, "", patchedDV.QuotaNotExceededReason)
+		if err != nil {
 			return err
 		}
 		anno[cc.AnnBoundCondition] = "false"

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -39,6 +39,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	"kubevirt.io/containerized-data-importer/pkg/common"
 	cc "kubevirt.io/containerized-data-importer/pkg/controller/common"
 	featuregates "kubevirt.io/containerized-data-importer/pkg/feature-gates"
@@ -157,6 +158,28 @@ func addCommonPopulatorsWatches(mgr manager.Manager, c controller.Controller, lo
 		return err
 	}
 
+	// When the resourceQuota is updated, it is necessary to trigger reconciliation for all populators that are waiting for quota expansion or removal.
+	if err := c.Watch(source.Kind(mgr.GetCache(), &corev1.ResourceQuota{}, handler.TypedEnqueueRequestsFromMapFunc[*corev1.ResourceQuota](
+		func(ctx context.Context, obj *corev1.ResourceQuota) []reconcile.Request {
+			dvList := &cdiv1.DataVolumeList{}
+			if err := mgr.GetClient().List(ctx, dvList, &client.ListOptions{Namespace: obj.Namespace}); err != nil {
+				return nil
+			}
+			var reqs []reconcile.Request
+			for _, dv := range dvList.Items {
+				for _, condition := range dv.Status.Conditions {
+					if condition.Type == patchedDV.QoutaNotExceededConditionType && condition.Status == corev1.ConditionFalse {
+						reqs = append(reqs, reconcile.Request{NamespacedName: types.NamespacedName{Name: dv.Name, Namespace: dv.Namespace}})
+					}
+				}
+			}
+			return reqs
+		},
+	),
+	)); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -225,7 +248,16 @@ func (r *ReconcilerBase) createPVCPrime(pvc *corev1.PersistentVolumeClaim, sourc
 			if innerErr != nil {
 				return nil, innerErr
 			}
+		} else {
+			innerErr := patchedDV.UpdateDVQuotaNotExceededConditionByPVC(r.client, pvc, corev1.ConditionTrue, "", patchedDV.QuotaNotExceededReason)
+			if innerErr != nil {
+				return nil, innerErr
+			}
 		}
+		return nil, err
+	}
+	err := patchedDV.UpdateDVQuotaNotExceededConditionByPVC(r.client, pvc, corev1.ConditionTrue, "", patchedDV.QuotaNotExceededReason)
+	if err != nil {
 		return nil, err
 	}
 	r.recorder.Eventf(pvc, corev1.EventTypeNormal, createdPVCPrimeSuccessfully, messageCreatedPVCPrimeSuccessfully)

--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -480,6 +480,14 @@ func (r *UploadReconciler) getOrCreateScratchPvc(pvc *corev1.PersistentVolumeCla
 					return nil, innerErr
 				}
 			}
+			innerErr := patchedDV.UpdateDVQuotaNotExceededConditionByPVC(r.client, pvc, corev1.ConditionTrue, "", patchedDV.QuotaNotExceededReason)
+			if innerErr != nil {
+				return nil, innerErr
+			}
+			return nil, err
+		}
+		err := patchedDV.UpdateDVQuotaNotExceededConditionByPVC(r.client, pvc, corev1.ConditionTrue, "", patchedDV.QuotaNotExceededReason)
+		if err != nil {
 			return nil, err
 		}
 	} else {

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -305,6 +305,7 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"resourcequotas",
 			},
 			Verbs: []string{
+				"get",
 				"list",
 				"watch",
 			},

--- a/pkg/operator/resources/cluster/controller.go
+++ b/pkg/operator/resources/cluster/controller.go
@@ -297,6 +297,18 @@ func getControllerClusterPolicyRules() []rbacv1.PolicyRule {
 				"watch",
 			},
 		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"resourcequotas",
+			},
+			Verbs: []string{
+				"list",
+				"watch",
+			},
+		},
 	}
 }
 

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -320,6 +320,7 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"resourcequotas",
 			},
 			Verbs: []string{
+				"get",
 				"list",
 				"watch",
 			},

--- a/pkg/operator/resources/operator/operator.go
+++ b/pkg/operator/resources/operator/operator.go
@@ -312,6 +312,18 @@ func getNamespacedPolicyRules() []rbacv1.PolicyRule {
 				"update",
 			},
 		},
+		{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"resourcequotas",
+			},
+			Verbs: []string{
+				"list",
+				"watch",
+			},
+		},
 	}
 	rules = append(rules, cdinamespaced.GetRolePolicyRules()...)
 	return rules


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

 Watch project quotas to enqueue DataVolumes and populators.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

