### PR TITLE
chore: rename importer and cloner containers to support integrity checking

### DIFF
--- a/pkg/controller/clone-controller.go
+++ b/pkg/controller/clone-controller.go
@@ -572,7 +572,7 @@ func MakeCloneSourcePodSpec(sourceVolumeMode corev1.PersistentVolumeMode, image,
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:            common.ClonerSourcePodName,
+					Name:            "d8v-cdi-clone-source",
 					Image:           image,
 					ImagePullPolicy: corev1.PullPolicy(pullPolicy),
 					Env: []corev1.EnvVar{

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -1343,7 +1343,7 @@ func CreateImporterTestPod(pvc *corev1.PersistentVolumeClaim, dvname string, scr
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:            common.ImporterPodName,
+					Name:            "d8v-cdi-importer",
 					Image:           "test/myimage",
 					ImagePullPolicy: corev1.PullPolicy("Always"),
 					Args:            []string{"-v=5"},

--- a/pkg/controller/import-controller.go
+++ b/pkg/controller/import-controller.go
@@ -970,7 +970,7 @@ func makeImporterPodSpec(args *importerPodArgs) *corev1.Pod {
 func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
 	containers := []corev1.Container{
 		{
-			Name:            common.ImporterPodName,
+			Name:            "d8v-cdi-importer",
 			Image:           args.image,
 			ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
 			Args:            []string{"-v=" + args.verbose},
@@ -991,7 +991,7 @@ func makeImporterContainerSpec(args *importerPodArgs) []corev1.Container {
 	}
 	if isRegistryNodeImport(args) {
 		containers = append(containers, corev1.Container{
-			Name:            "server",
+			Name:            "d8v-cdi-registrynode-server",
 			Image:           args.importImage,
 			ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
 			Command:         []string{"/shared/server", "-p", "8100", "-image-dir", "/disk", "-ready-file", "/shared/ready", "-done-file", "/shared/done"},
@@ -1124,7 +1124,7 @@ func makeImporterInitContainersSpec(args *importerPodArgs) []corev1.Container {
 	var initContainers []corev1.Container
 	if isRegistryNodeImport(args) {
 		initContainers = append(initContainers, corev1.Container{
-			Name:            "init",
+			Name:            "d8v-cdi-init",
 			Image:           args.image,
 			ImagePullPolicy: corev1.PullPolicy(args.pullPolicy),
 			Command:         []string{"sh", "-c", "cp /usr/bin/cdi-containerimage-server /shared/server"},

--- a/tests/import_test.go
+++ b/tests/import_test.go
@@ -349,7 +349,7 @@ var _ = Describe("[Istio] Namespace sidecar injection", Serial, func() {
 				Pods(importer.Namespace).
 				GetLogs(importer.Name, &v1.PodLogOptions{
 					SinceTime: &metav1.Time{Time: CurrentSpecReport().StartTime},
-					Container: "importer",
+					Container: "d8v-cdi-importer",
 				}).
 				DoRaw(context.Background())
 			return string(out), err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add d8v- prefix to containers in cdi-importer and cdi-cloner Pods.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

