### PR TITLE
chore: rename containers, add d8v prefix for strict environment (port to upstream from cse branch)

### DIFF
--- a/pkg/controller/upload-controller.go
+++ b/pkg/controller/upload-controller.go
@@ -30,7 +30,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -825,7 +825,7 @@ func (r *UploadReconciler) makeUploadPodContainers(args UploadPodArgs, resourceR
 	requestImageSize, _ := cc.GetRequestedImageSize(args.PVC)
 	containers := []corev1.Container{
 		{
-			Name:            common.UploadServerPodname,
+			Name:            "d8v-cdi-upload-server",
 			Image:           r.image,
 			ImagePullPolicy: corev1.PullPolicy(r.pullPolicy),
 			Env: []corev1.EnvVar{

--- a/pkg/controller/upload-controller_test.go
+++ b/pkg/controller/upload-controller_test.go
@@ -768,7 +768,7 @@ func createUploadClonePod(pvc *corev1.PersistentVolumeClaim, clientName string) 
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:            "cdi-upload-server",
+					Name:            "d8v-cdi-upload-server",
 					Image:           "test/myimage",
 					ImagePullPolicy: corev1.PullPolicy("Always"),
 					VolumeMounts: []corev1.VolumeMount{

--- a/pkg/monitoring/rules/recordingrules/pods.go
+++ b/pkg/monitoring/rules/recordingrules/pods.go
@@ -20,7 +20,7 @@ var podsRecordingRules = []operatorrules.RecordingRule{
 		},
 		MetricType: operatormetrics.GaugeType,
 		Expr: intstr.FromString(
-			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.ImporterPodName, common.ImporterPodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.ImporterPodName, "d8v-cdi-importer", strconv.Itoa(common.UnusualRestartCountThreshold)),
 		),
 	},
 	{
@@ -30,7 +30,7 @@ var podsRecordingRules = []operatorrules.RecordingRule{
 		},
 		MetricType: operatormetrics.GaugeType,
 		Expr: intstr.FromString(
-			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.UploadPodName, common.UploadServerPodname, strconv.Itoa(common.UnusualRestartCountThreshold)),
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'%s-.*', container='%s'} > %s) or on() vector(0)", common.UploadPodName, "d8v-cdi-upload-server", strconv.Itoa(common.UnusualRestartCountThreshold)),
 		),
 	},
 	{
@@ -40,7 +40,7 @@ var podsRecordingRules = []operatorrules.RecordingRule{
 		},
 		MetricType: operatormetrics.GaugeType,
 		Expr: intstr.FromString(
-			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'.*%s', container='%s'} > %s) or on() vector(0)", common.ClonerSourcePodNameSuffix, common.ClonerSourcePodName, strconv.Itoa(common.UnusualRestartCountThreshold)),
+			fmt.Sprintf("count(kube_pod_container_status_restarts_total{pod=~'.*%s', container='%s'} > %s) or on() vector(0)", common.ClonerSourcePodNameSuffix, "d8v-cdi-clone-source", strconv.Itoa(common.UnusualRestartCountThreshold)),
 		),
 	},
 }


### PR DESCRIPTION
- Rename more containers for checkings in strict environment.
- Fix container names in recording rules.

