### PR TITLE
chore: rename containers in prep and cloner pods

### DIFF
--- a/pkg/controller/clone/prep-claim.go
+++ b/pkg/controller/clone/prep-claim.go
@@ -159,7 +159,7 @@ func (p *PrepClaimPhase) createPod(ctx context.Context, name string, pvc *corev1
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{
 				{
-					Name:            "dummy",
+					Name:            "d8v-dummy",
 					Image:           p.Image,
 					ImagePullPolicy: p.PullPolicy,
 					Command:         []string{"/bin/hello"},

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -757,7 +757,7 @@ func makeSizeDetectionObjectMeta(sourcePvc *corev1.PersistentVolumeClaim) *metav
 // makeSizeDetectionContainerSpec creates and returns the size-detection pod's Container spec
 func (r *PvcCloneReconciler) makeSizeDetectionContainerSpec(volName string) *corev1.Container {
 	container := corev1.Container{
-		Name:            "size-detection-volume",
+		Name:            "d8v-size-detection-volume",
 		Image:           r.importerImage,
 		ImagePullPolicy: corev1.PullPolicy(r.pullPolicy),
 		Command:         []string{"/usr/bin/cdi-image-size-detection"},


### PR DESCRIPTION
Containers should have `d8v-` prefix to run in stricted environments.