### PR TITLE
chore: add heritage=deckhouse label for Pods in user ns

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -308,6 +308,11 @@ const (
 	QuotaExcludeValue = "true"
 	// QuotaExcludeLabel provides a constant  for exclude quota label.
 	QuotaExcludeLabel = "resource-quota-overrides.deckhouse.io/ignore"
+
+	// HeritageLabel is a label that apply deckhouse policies on system Pods in user namespaces:
+	// forbid deletion, exec, connect for non-system users.
+	HeritageLabel     string = "heritage"
+	HeritageDeckhouse string = "deckhouse"
 )
 
 // ProxyPaths are all supported paths

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -311,8 +311,8 @@ const (
 
 	// HeritageLabel is a label that apply deckhouse policies on system Pods in user namespaces:
 	// forbid deletion, exec, connect for non-system users.
-	HeritageLabel     string = "heritage"
-	HeritageDeckhouse string = "deckhouse"
+	HeritageLabel string = "heritage"
+	HeritageValue string = "deckhouse"
 )
 
 // ProxyPaths are all supported paths

--- a/pkg/controller/datavolume/pvc-clone-controller.go
+++ b/pkg/controller/datavolume/pvc-clone-controller.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
+	"kubevirt.io/containerized-data-importer/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -662,6 +663,7 @@ func (r *PvcCloneReconciler) getOrCreateSizeDetectionPod(
 		if pod == nil {
 			return nil, errors.Errorf("Size-detection pod spec could not be generated")
 		}
+		util.SetRecommendedLabels(pod, r.installerLabels, "pvc-clone-controller")
 		// Create the pod
 		if err := r.client.Create(context.TODO(), pod); err != nil {
 			if !k8serrors.IsAlreadyExists(err) {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -209,7 +209,7 @@ func SetRecommendedLabels(obj metav1.Object, installerLabels map[string]string, 
 	staticLabels := map[string]string{
 		common.AppKubernetesManagedByLabel: controllerName,
 		common.AppKubernetesComponentLabel: "storage",
-		common.HeritageLabel:               common.HeritageDeckhouse,
+		common.HeritageLabel:               common.HeritageValue,
 	}
 
 	// Merge static & existing labels

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -209,6 +209,7 @@ func SetRecommendedLabels(obj metav1.Object, installerLabels map[string]string, 
 	staticLabels := map[string]string{
 		common.AppKubernetesManagedByLabel: controllerName,
 		common.AppKubernetesComponentLabel: "storage",
+		"heritage":                         "deckhouse",
 	}
 
 	// Merge static & existing labels

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -209,7 +209,7 @@ func SetRecommendedLabels(obj metav1.Object, installerLabels map[string]string, 
 	staticLabels := map[string]string{
 		common.AppKubernetesManagedByLabel: controllerName,
 		common.AppKubernetesComponentLabel: "storage",
-		"heritage":                         "deckhouse",
+		common.HeritageLabel:               common.HeritageDeckhouse,
 	}
 
 	// Merge static & existing labels


### PR DESCRIPTION
Support security hardening for Deckhouse system components implemented by https://github.com/deckhouse/deckhouse/pull/16749

Add heritage=deckhouse label to Pods that run in user namespaces:

- cdi-importer-*
- cdi-uploader-*
- cdi-clone-*
- prep-* (cdi-populator-prep)
- size-detection-*

