### PR TITLE
chore: rename provisioner annotation prefix

### DIFF
--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -98,9 +98,9 @@ const (
 	AnnExternalPopulation = AnnAPIGroup + "/externalPopulation"
 
 	// AnnProvisionerTolerations annotation specifies tolerations to use for provisioners.
-	AnnProvisionerTolerations = "virt.deckhouse.io/provisioner-tolerations"
+	AnnProvisionerTolerations = "internal.virtualization.deckhouse.io/provisioner-tolerations"
 	// AnnProvisionerName provides a name of data volume provisioner.
-	AnnProvisionerName = "virt.deckhouse.io/provisioner-name"
+	AnnProvisionerName = "internal.virtualization.deckhouse.io/provisioner-name"
 
 	// AnnDeleteAfterCompletion is PVC annotation for deleting DV after completion
 	AnnDeleteAfterCompletion = AnnAPIGroup + "/storage.deleteAfterCompletion"

--- a/pkg/controller/common/util.go
+++ b/pkg/controller/common/util.go
@@ -99,8 +99,12 @@ const (
 
 	// AnnProvisionerTolerations annotation specifies tolerations to use for provisioners.
 	AnnProvisionerTolerations = "internal.virtualization.deckhouse.io/provisioner-tolerations"
+	// AnnProvisionerTolerationsLegacy is the legacy annotation for provisioner tolerations.
+	AnnProvisionerTolerationsLegacy = "virt.deckhouse.io/provisioner-tolerations"
 	// AnnProvisionerName provides a name of data volume provisioner.
 	AnnProvisionerName = "internal.virtualization.deckhouse.io/provisioner-name"
+	// AnnProvisionerNameLegacy is the legacy annotation for the data volume provisioner name.
+	AnnProvisionerNameLegacy = "virt.deckhouse.io/provisioner-name"
 
 	// AnnDeleteAfterCompletion is PVC annotation for deleting DV after completion
 	AnnDeleteAfterCompletion = AnnAPIGroup + "/storage.deleteAfterCompletion"
@@ -821,6 +825,10 @@ func AdjustWorkloadNodePlacement(ctx context.Context, c client.Client, nodePlace
 
 func ExtractProvisionerTolerations(obj client.Object) ([]corev1.Toleration, error) {
 	rawTolerations := obj.GetAnnotations()[AnnProvisionerTolerations]
+
+	if rawTolerations == "" {
+		rawTolerations = obj.GetAnnotations()[AnnProvisionerTolerationsLegacy]
+	}
 
 	if rawTolerations == "" {
 		return nil, nil

--- a/pkg/controller/datavolume/controller-base.go
+++ b/pkg/controller/datavolume/controller-base.go
@@ -1172,8 +1172,11 @@ func (r *ReconcilerBase) newPersistentVolumeClaim(dataVolume *cdiv1.DataVolume, 
 	}
 	annotations[cc.AnnPodRestarts] = "0"
 
-	if dataVolume.Annotations[cc.AnnProvisionerTolerations] != "" {
+	switch {
+	case dataVolume.Annotations[cc.AnnProvisionerTolerations] != "":
 		annotations[cc.AnnProvisionerTolerations] = dataVolume.Annotations[cc.AnnProvisionerTolerations]
+	case dataVolume.Annotations[cc.AnnProvisionerTolerationsLegacy] != "":
+		annotations[cc.AnnProvisionerTolerations] = dataVolume.Annotations[cc.AnnProvisionerTolerationsLegacy]
 	}
 
 	annotations[cc.AnnContentType] = string(cc.GetContentType(dataVolume.Spec.ContentType))

--- a/pkg/controller/populators/populator-base.go
+++ b/pkg/controller/populators/populator-base.go
@@ -269,7 +269,7 @@ type updatePVCAnnotationsFunc func(pvc, pvcPrime *corev1.PersistentVolumeClaim)
 
 var desiredAnnotations = []string{cc.AnnPodPhase, cc.AnnPodReady, cc.AnnPodRestarts,
 	cc.AnnPreallocationRequested, cc.AnnPreallocationApplied, cc.AnnCurrentCheckpoint, cc.AnnMultiStageImportDone,
-	cc.AnnRunningCondition, cc.AnnRunningConditionMessage, cc.AnnRunningConditionReason, cc.AnnProvisionerName}
+	cc.AnnRunningCondition, cc.AnnRunningConditionMessage, cc.AnnRunningConditionReason, cc.AnnProvisionerName, cc.AnnProvisionerNameLegacy}
 
 func (r *ReconcilerBase) updatePVCWithPVCPrimeAnnotations(pvc, pvcPrime *corev1.PersistentVolumeClaim, updateFunc updatePVCAnnotationsFunc) (*corev1.PersistentVolumeClaim, error) {
 	pvcCopy := pvc.DeepCopy()


### PR DESCRIPTION
## Summary
- Rename provisioner annotation keys from `virt.deckhouse.io` to `internal.virtualization.deckhouse.io`.
- Keep provisioner tolerations and provisioner name annotations under the internal virtualization Deckhouse domain.
Applied to virtualization-controller by patch: https://github.com/deckhouse/virtualization/pull/2428

## Test plan
- Not run: constant-only annotation rename.