### PR TITLE
feat(importer): support ServiceAccount token auth for registry source

### DIFF
--- a/pkg/importer/transport.go
+++ b/pkg/importer/transport.go
@@ -40,6 +40,15 @@ import (
 
 const (
 	whFilePrefix = ".wh."
+
+	// serviceAccountTokenUsername is a sentinel accessKeyId that switches registry
+	// authentication to the Pod's projected ServiceAccount token. It is set by the
+	// Deckhouse Virtualization controller in the registry auth Secret when
+	// per-namespace DVCR authorization is enabled. Must match the constant on the
+	// controller side (pkg/controller/supplements/copier).
+	serviceAccountTokenUsername = "dvcr-serviceaccount-token-auth"
+	// serviceAccountTokenPath is the standard in-cluster projected SA token path.
+	serviceAccountTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 )
 
 func commandTimeoutContext() (context.Context, context.CancelFunc) {
@@ -48,7 +57,19 @@ func commandTimeoutContext() (context.Context, context.CancelFunc) {
 
 func buildSourceContext(accessKey, secKey, certDir string, insecureRegistry bool) *types.SystemContext {
 	ctx := &types.SystemContext{}
-	if accessKey != "" && secKey != "" {
+	if accessKey == serviceAccountTokenUsername {
+		// Per-namespace DVCR authorization: authenticate with the Pod's projected
+		// ServiceAccount token. Read fresh on every call (buildSourceContext runs
+		// per registry operation) so kubelet rotation of the token file does not
+		// break long-running imports. On read error, proceed unauthenticated and
+		// let the registry return 401.
+		if token, err := os.ReadFile(serviceAccountTokenPath); err == nil {
+			ctx.DockerAuthConfig = &types.DockerAuthConfig{
+				Username: "sa",
+				Password: strings.TrimSpace(string(token)),
+			}
+		}
+	} else if accessKey != "" && secKey != "" {
 		ctx.DockerAuthConfig = &types.DockerAuthConfig{
 			Username: accessKey,
 			Password: secKey,


### PR DESCRIPTION
**What this PR does / why we need it**:

When the registry auth Secret sets `accessKeyId` to the sentinel value `dvcr-serviceaccount-token-auth`, the importer authenticates to the source registry with the Pod's projected ServiceAccount token instead of static credentials. The token is read fresh inside `buildSourceContext` (invoked per registry operation), so kubelet rotation of the token file does not break long-running imports.

This lets the Deckhouse Virtualization controller stop copying a shared read-write registry credential into tenant namespaces for VirtualDisk imports: the importer Pod authenticates with its own namespace-scoped identity, which the registry authorizes per namespace.

Behavior is unchanged unless the sentinel `accessKeyId` is set — regular `accessKeyId`/`secretKey` credentials work exactly as before.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Single self-contained change in `pkg/importer/transport.go`; the token file is the standard in-cluster projected SA token path. Consumed by the Deckhouse Virtualization module (paired controller change references this branch).

**Release note**:
```release-note
NONE
```
